### PR TITLE
chore(deps): update docs to Node 26 and setup-node v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,16 @@ permissions:
   contents: read
 
 jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "26"
+      - name: Build docs site
+        run: make docs-site
+
   build:
     runs-on: macos-15
     steps:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -34,9 +34,9 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
-          node-version: "24"
+          node-version: "26"
 
       - name: Build docs site
         run: make docs-site

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Update the docs workflow to Node.js 26 and `actions/setup-node@v7`, and verify the docs build in pull-request CI.
 - Bound `doctor` rich-read sqlite3 probes to 30 seconds so a stuck local database query fails with a timeout instead of hanging the CLI. Thanks @SebTardif.
 
 ## 0.3.4 - 2026-08-09


### PR DESCRIPTION
The docs workflow still used setup-node v6 and Node.js 24. This updates it to setup-node v7 and Node.js 26, and adds a matching docs build to pull-request CI so the runtime and Action are exercised before deployment. No application behavior changes.

Updates:
- GitHub Actions: `actions/setup-node` v6 → v7 (current v7.0.0).
- Docs runtime: Node.js 24 → 26, verified locally with v26.8.1.
- Add the docs build to CI; record the change under Unreleased.

The Swift dependency Commander is already current at 0.2.4, and `swift package update` made no lockfile changes. The pnpm manifest has no dependencies; frozen installation succeeded without changes. Checkout v7, configure-pages v6, upload-pages-artifact v5, deploy-pages v5, and the create-github-app-token v3.2.0 SHA pin are current. No held upgrades or superseded dependency-bot PRs.

Proof on macOS arm64 with Swift 6.4:
- `pnpm install --frozen-lockfile` and `swift package update`: passed; lockfiles unchanged.
- `make check`: all four linters passed; SwiftLint reported 0 violations in 69 files; 81 Swift tests across 24 suites passed; coverage 91.5% (876/957 lines, minimum 90%).
- `make build`: passed; built CLI `--version` returned 0.3.4 and `--help` succeeded without accessing Reminders.
- `make release-harness`: 21 scenario groups passed with credential-free mocks.
- `make macos-artifact`: local-only universal arm64/x86_64 candidate built and passed architecture/signature checks. No release or publication performed.
- `make docs-site`: passed with Node 24.20.0 and 26.8.1; all 9 output files, including 5 HTML pages, were byte-for-byte identical.
- Codex autoreview: no actionable blockers.

Baseline main CI was green: [CI](https://github.com/openclaw/remindctl/actions/runs/32895460126), [Pages](https://github.com/openclaw/remindctl/actions/runs/31350070111), [ClawSweeper Dispatch](https://github.com/openclaw/remindctl/actions/runs/33072539903), and [release verification](https://github.com/openclaw/remindctl/actions/runs/31350808299). No baseline CI repair was needed. Swift 6.4 emits an existing unstructured-task warning in AsyncTimeoutTests; it does not fail the gates and is unchanged.
