### PR TITLE
fix: do not trap on nil calendar after add/edit/complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Return a calendar-missing error from add, edit, and complete instead of trapping when EventKit leaves a reminder without a calendar after save. Thanks @SebTardif.
+
 ## 0.3.5 - 2026-08-30
 
 - Skip fetched reminders with a missing calendar so orphaned rows cannot crash reminder reads. Thanks @SebTardif.

--- a/README.md
+++ b/README.md
@@ -288,6 +288,7 @@ When running over SSH, grant access on the Mac that actually runs `remindctl`.
 ## EventKit Limits
 
 Reminder reads skip orphaned EventKit reminders whose calendar is missing; other reminders remain available.
+If a calendar is missing after `add`, `edit`, or `complete` saves a reminder, the command reports `Reminder is missing a calendar` instead of crashing. The change has already been saved; check Reminders.app before retrying.
 
 `remindctl` intentionally sticks to public EventKit APIs. These Reminders.app features are not exposed through EventKit today:
 

--- a/Sources/RemindCore/EventKitStore.swift
+++ b/Sources/RemindCore/EventKitStore.swift
@@ -136,7 +136,7 @@ public actor RemindersStore {
       reminder.addAlarm(try await locationAlarm(from: locationTrigger))
     }
     try eventStore.save(reminder, commit: true)
-    return item(from: reminder)
+    return try item(from: reminder)
   }
 
   public func updateReminder(id: String, update: ReminderUpdate) async throws -> ReminderItem {
@@ -182,7 +182,7 @@ public actor RemindersStore {
 
     try eventStore.save(reminder, commit: true)
 
-    return item(from: reminder)
+    return try item(from: reminder)
   }
 
   public func completeReminders(ids: [String]) async throws -> [ReminderItem] {
@@ -191,7 +191,7 @@ public actor RemindersStore {
       let reminder = try reminder(withID: id)
       reminder.isCompleted = true
       try eventStore.save(reminder, commit: true)
-      updated.append(item(from: reminder))
+      updated.append(try item(from: reminder))
     }
     return updated
   }
@@ -237,6 +237,30 @@ extension RemindersStore {
     let locationTrigger: LocationTrigger?
     let listID: String
     let listName: String
+  }
+
+  static func reminderItem(from reminder: EKReminder, calendar: Calendar = .current) throws -> ReminderItem {
+    guard let data = reminderData(from: reminder) else {
+      throw RemindCoreError.operationFailed("Reminder is missing a calendar")
+    }
+    return ReminderItem(
+      id: data.id,
+      title: data.title,
+      notes: data.notes,
+      url: data.url,
+      isCompleted: data.isCompleted,
+      completionDate: data.completionDate,
+      creationDate: data.creationDate,
+      lastModifiedDate: data.lastModifiedDate,
+      priority: ReminderPriority(eventKitValue: data.priority),
+      dueDate: data.dueDateComponents.flatMap { calendar.date(from: $0) },
+      dueDateIsAllDay: data.dueDateIsAllDay,
+      alarmDate: data.alarmDate,
+      recurrenceRule: data.recurrenceRule,
+      locationTrigger: data.locationTrigger,
+      listID: data.listID,
+      listName: data.listName
+    )
   }
 
   static func reminderData(from reminder: EKReminder) -> ReminderData? {
@@ -368,26 +392,8 @@ extension RemindersStore {
     return calendar.date(from: components)
   }
 
-  private func item(from reminder: EKReminder) -> ReminderItem {
-    let components = reminder.dueDateComponents
-    return ReminderItem(
-      id: reminder.calendarItemIdentifier,
-      title: reminder.title ?? "",
-      notes: reminder.notes,
-      url: reminder.url,
-      isCompleted: reminder.isCompleted,
-      completionDate: reminder.completionDate,
-      creationDate: reminder.creationDate,
-      lastModifiedDate: reminder.lastModifiedDate,
-      priority: ReminderPriority(eventKitValue: Int(reminder.priority)),
-      dueDate: date(from: components),
-      dueDateIsAllDay: isAllDay(components),
-      alarmDate: Self.alarmDate(from: reminder),
-      recurrenceRule: Self.recurrenceRule(from: reminder),
-      locationTrigger: Self.locationTrigger(from: reminder),
-      listID: reminder.calendar.calendarIdentifier,
-      listName: reminder.calendar.title
-    )
+  private func item(from reminder: EKReminder) throws -> ReminderItem {
+    try Self.reminderItem(from: reminder, calendar: calendar)
   }
 
   private static func alarmDate(from reminder: EKReminder) -> Date? {

--- a/Tests/RemindCoreTests/ReminderSnapshotTests.swift
+++ b/Tests/RemindCoreTests/ReminderSnapshotTests.swift
@@ -53,4 +53,37 @@ struct ReminderSnapshotTests {
     #expect(snapshot.alarmDate == alarmDate)
     #expect(snapshot.recurrenceRule == RecurrenceRule(frequency: .weekly, interval: 2))
   }
+
+  @Test("Mutation mapping errors instead of trapping when calendar is missing")
+  func mutationMappingErrorsOnMissingCalendar() throws {
+    let reminder = EKReminder(eventStore: EKEventStore())
+    reminder.title = "Orphan"
+    try #require(reminder.calendar == nil)
+
+    #expect(throws: RemindCoreError.operationFailed("Reminder is missing a calendar")) {
+      _ = try RemindersStore.reminderItem(from: reminder)
+    }
+  }
+
+  @Test("Mutation mapping keeps list identity for a reminder with a calendar")
+  func mutationMappingPreservesCalendar() throws {
+    let store = EKEventStore()
+    let calendar = EKCalendar(for: .reminder, eventStore: store)
+    calendar.title = "Synthetic list"
+    let reminder = EKReminder(eventStore: store)
+    reminder.calendar = calendar
+    reminder.title = "Keep me"
+    reminder.notes = "Synthetic notes"
+    reminder.priority = 5
+
+    let item = try RemindersStore.reminderItem(from: reminder)
+
+    #expect(item.id == reminder.calendarItemIdentifier)
+    #expect(item.title == "Keep me")
+    #expect(item.notes == "Synthetic notes")
+    #expect(item.priority == .medium)
+    #expect(item.listID == calendar.calendarIdentifier)
+    #expect(item.listName == "Synthetic list")
+    #expect(!item.isCompleted)
+  }
 }

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -69,6 +69,8 @@ remindctl edit 4A83 --no-repeat
 
 `edit`, `complete`, and `delete` accept indexes from the current default listing or ID prefixes.
 
+If `add`, `edit`, or `complete` reports `Reminder is missing a calendar`, EventKit saved the reminder but returned it without its list. Check Reminders.app before retrying; this error does not roll back the saved change.
+
 Changing or clearing only the due date leaves every alarm unchanged. Explicit alarm edits preserve relative and location-based alarms while replacing or clearing absolute alarms.
 
 ## Lists


### PR DESCRIPTION
`add`, `edit`, and `complete` can trap while producing their result after EventKit has successfully saved a reminder whose calendar is missing. The read path already skips these orphaned reminders (#72), but the post-save mapper still dereferenced EventKit's implicitly unwrapped calendar.

All three mutation paths now use a throwing mapper backed by the existing guarded snapshot extraction. A missing calendar produces `Reminder is missing a calendar`; normal reminders retain their metadata. The README and command documentation explain that this error happens after the save and does not roll it back, so callers should check Reminders.app before retrying.

Thanks @SebTardif for the fix and regression tests. The original contributor commit is preserved, with a maintainer documentation follow-up.

### Validation

Verified on macOS 26.6.2, Apple Silicon, Apple Swift 6.4:

- `make check`: all 85 Swift Testing tests passed; strict lint passed; scoped RemindCore coverage is 92.2% (882/957), above the 90% gate.
- `make docs-site` and `make release-harness`: passed.
- `make macos-artifact`: built and verified both arm64 and x86_64 slices. A local copy signed with the documented OpenClaw Foundation Developer ID passed signature verification and ran `--version`, `status --json`, and `complete --help`.
- A standalone executable linked against this branch's built `libRemindCore.a`, using `@testable import RemindCore`, called **the production `RemindersStore.reminderItem(from:calendar:)`** on real in-memory EventKit objects. A new `EKReminder` with `calendar == nil` returned the expected `RemindCoreError.operationFailed("Reminder is missing a calendar")` and exited normally. Valid-calendar probes preserved identity, title, notes, URL, priority, timed due date, alarm, recurrence, and all-day due dates. This executed the compiled production mapper used by add/edit/complete; the guard was not copied into the probe.
- Isolated Codex review of the complete candidate against main found no actionable P0–P2 findings.

The standalone probe was compiled with `swiftc -I .build/out/Products/Debug -L .build/out/Products/Debug -lRemindCore -profile-generate`, then Developer ID-signed and executed. Its source created synthetic `EKReminder`/`EKCalendar` objects and asserted the production mapper's result. It performed no store fetch, save, delete, or authorization request. This closes the compiled-mapper proof gap from the earlier review. A saved orphaned reminder was not manufactured; local Reminders permission remains `not-determined`.

Dependency audit found no required updates: Commander is at latest 0.2.4, there are no npm dependencies, and current Action major references cover the latest published releases. No version or release change is included.
