### PR TITLE
fix: make list --create a no-op when the list exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Make `list --create` reuse a unique existing list instead of inserting another calendar with the same title. Thanks @SebTardif.
 - Return a calendar-missing error from add, edit, and complete instead of trapping when EventKit leaves a reminder without a calendar after save. Thanks @SebTardif.
 
 ## 0.3.5 - 2026-08-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Make `list --create` reuse a unique existing list instead of inserting another calendar with the same title. Thanks @SebTardif.
+- Make `list --create` reuse a unique existing list instead of inserting another calendar with the same title, and report its current reminder counts in JSON. Thanks @SebTardif.
 - Return a calendar-missing error from add, edit, and complete instead of trapping when EventKit leaves a reminder without a calendar after save. Thanks @SebTardif.
 
 ## 0.3.5 - 2026-08-30

--- a/Sources/remindctl/Commands/ListCommand.swift
+++ b/Sources/remindctl/Commands/ListCommand.swift
@@ -104,14 +104,27 @@ enum ListCommand {
           guard let name else {
             throw ParsedValuesError.missingArgument("name")
           }
-          let list = try await store.createList(name: name)
+          let existing = try existingListForCreate(name: name, lists: await store.lists())
+          let list: ReminderList
+          let created: Bool
+          if let existing {
+            list = existing
+            created = false
+          } else {
+            list = try await store.createList(name: name)
+            created = true
+          }
           if runtime.outputFormat == .json {
             OutputRenderer.printLists(
               [ListSummary(id: list.id, title: list.title, reminderCount: 0, overdueCount: 0)],
               format: runtime.outputFormat
             )
           } else if runtime.outputFormat == .standard {
-            Swift.print("Created list \"\(list.title)\"")
+            if created {
+              Swift.print("Created list \"\(list.title)\"")
+            } else {
+              Swift.print("List \"\(list.title)\" already exists")
+            }
           }
           return
         }
@@ -148,6 +161,17 @@ enum ListCommand {
       }
 
       OutputRenderer.printLists(summaries, format: runtime.outputFormat)
+    }
+  }
+
+  static func existingListForCreate(name: String, lists: [ReminderList]) throws -> ReminderList? {
+    do {
+      return try ListResolver.resolve(name, in: lists)
+    } catch let error as RemindCoreError {
+      guard case .listNotFound = error else {
+        throw error
+      }
+      return nil
     }
   }
 

--- a/Sources/remindctl/Commands/ListCommand.swift
+++ b/Sources/remindctl/Commands/ListCommand.swift
@@ -115,8 +115,9 @@ enum ListCommand {
             created = true
           }
           if runtime.outputFormat == .json {
+            let reminders = created ? [] : try await store.reminders(matching: .id(list.id))
             OutputRenderer.printLists(
-              [ListSummary(id: list.id, title: list.title, reminderCount: 0, overdueCount: 0)],
+              summaries(for: [list], reminders: reminders),
               format: runtime.outputFormat
             )
           } else if runtime.outputFormat == .standard {
@@ -142,25 +143,32 @@ enum ListCommand {
       let lists = await store.lists()
       let reminders = try await store.reminders(in: nil)
 
-      let startOfToday = Calendar.current.startOfDay(for: Date())
-      var counts: [String: (total: Int, overdue: Int)] = [:]
-      for reminder in reminders where !reminder.isCompleted {
-        let entry = counts[reminder.listID] ?? (0, 0)
-        let overdue = (reminder.dueDate.map { $0 < startOfToday } ?? false) ? 1 : 0
-        counts[reminder.listID] = (entry.total + 1, entry.overdue + overdue)
-      }
+      OutputRenderer.printLists(summaries(for: lists, reminders: reminders), format: runtime.outputFormat)
+    }
+  }
 
-      let summaries = lists.map { list in
-        let entry = counts[list.id] ?? (0, 0)
-        return ListSummary(
-          id: list.id,
-          title: list.title,
-          reminderCount: entry.total,
-          overdueCount: entry.overdue
-        )
-      }
+  static func summaries(
+    for lists: [ReminderList],
+    reminders: [ReminderItem],
+    now: Date = Date(),
+    calendar: Calendar = .current
+  ) -> [ListSummary] {
+    let startOfToday = calendar.startOfDay(for: now)
+    var counts: [String: (total: Int, overdue: Int)] = [:]
+    for reminder in reminders where !reminder.isCompleted {
+      let entry = counts[reminder.listID] ?? (0, 0)
+      let overdue = (reminder.dueDate.map { $0 < startOfToday } ?? false) ? 1 : 0
+      counts[reminder.listID] = (entry.total + 1, entry.overdue + overdue)
+    }
 
-      OutputRenderer.printLists(summaries, format: runtime.outputFormat)
+    return lists.map { list in
+      let entry = counts[list.id] ?? (0, 0)
+      return ListSummary(
+        id: list.id,
+        title: list.title,
+        reminderCount: entry.total,
+        overdueCount: entry.overdue
+      )
     }
   }
 

--- a/Tests/remindctlTests/ListCommandTests.swift
+++ b/Tests/remindctlTests/ListCommandTests.swift
@@ -1,5 +1,6 @@
 import Testing
 
+@testable import RemindCore
 @testable import remindctl
 
 @MainActor
@@ -30,5 +31,36 @@ struct ListCommandTests {
     #expect(OpenCommand.shouldShowOpenReminders(id: nil, listName: nil, listID: "LIST", app: false))
     #expect(!OpenCommand.shouldShowOpenReminders(id: nil, listName: "Work", listID: nil, app: true))
     #expect(!OpenCommand.shouldShowOpenReminders(id: "A123", listName: nil, listID: nil, app: false))
+  }
+
+  @Test("Create plans a new list when no matching list exists")
+  func createPlansNewListWhenMissing() throws {
+    let lists = [
+      ReminderList(id: "AAAA-1111", title: "Work")
+    ]
+    #expect(try ListCommand.existingListForCreate(name: "Projects", lists: lists) == nil)
+  }
+
+  @Test("Create reuses a unique existing list instead of inserting another")
+  func createReusesUniqueExistingList() throws {
+    let existing = ReminderList(id: "AAAA-1111", title: "Projects")
+    #expect(try ListCommand.existingListForCreate(name: "Projects", lists: [existing]) == existing)
+  }
+
+  @Test("Create reuses a unique case-insensitive match")
+  func createReusesCaseInsensitiveMatch() throws {
+    let existing = ReminderList(id: "AAAA-1111", title: "Projects")
+    #expect(try ListCommand.existingListForCreate(name: "projects", lists: [existing]) == existing)
+  }
+
+  @Test("Create rejects an already-ambiguous list name")
+  func createRejectsAmbiguousExistingName() {
+    let lists = [
+      ReminderList(id: "AAAA-1111", title: "Projects"),
+      ReminderList(id: "BBBB-2222", title: "Projects"),
+    ]
+    #expect(throws: RemindCoreError.self) {
+      _ = try ListCommand.existingListForCreate(name: "Projects", lists: lists)
+    }
   }
 }

--- a/Tests/remindctlTests/ListCommandTests.swift
+++ b/Tests/remindctlTests/ListCommandTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 
 @testable import RemindCore
@@ -51,6 +52,53 @@ struct ListCommandTests {
   func createReusesCaseInsensitiveMatch() throws {
     let existing = ReminderList(id: "AAAA-1111", title: "Projects")
     #expect(try ListCommand.existingListForCreate(name: "projects", lists: [existing]) == existing)
+  }
+
+  @Test("Create reuses a unique normalized list name")
+  func createReusesNormalizedMatch() throws {
+    let existing = ReminderList(id: "AAAA-1111", title: "📋 Projects!")
+    #expect(try ListCommand.existingListForCreate(name: "projects", lists: [existing]) == existing)
+  }
+
+  @Test("Reused list summaries count open and overdue reminders by list ID")
+  func reusedListCounts() throws {
+    var calendar = Calendar(identifier: .gregorian)
+    calendar.timeZone = try #require(TimeZone(secondsFromGMT: 0))
+    let now = Date(timeIntervalSince1970: 1_700_049_600)
+    let today = calendar.startOfDay(for: now)
+    let cases: [(id: String, listID: String, completed: Bool, due: Date?)] = [
+      ("overdue", "A", false, today.addingTimeInterval(-1)),
+      ("today", "A", false, today),
+      ("future", "A", false, today.addingTimeInterval(86_400)),
+      ("undated", "A", false, nil),
+      ("completed", "A", true, today.addingTimeInterval(-1)),
+      ("other-list", "B", false, today.addingTimeInterval(-1)),
+    ]
+    let reminders = cases.map { item in
+      ReminderItem(
+        id: item.id,
+        title: item.id,
+        notes: nil,
+        isCompleted: item.completed,
+        completionDate: nil,
+        priority: .none,
+        dueDate: item.due,
+        listID: item.listID,
+        listName: "Projects"
+      )
+    }
+    let summaries = ListCommand.summaries(
+      for: [ReminderList(id: "A", title: "Projects"), ReminderList(id: "empty", title: "Empty")],
+      reminders: reminders,
+      now: now,
+      calendar: calendar
+    )
+    #expect(summaries.count == 2)
+    #expect(summaries[0].id == "A")
+    #expect(summaries[0].reminderCount == 4)
+    #expect(summaries[0].overdueCount == 1)
+    #expect(summaries[1].reminderCount == 0)
+    #expect(summaries[1].overdueCount == 0)
   }
 
   @Test("Create rejects an already-ambiguous list name")

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -86,6 +86,7 @@ remindctl list --list-id 7A12 --rename Archive
 ```
 
 Mutating list operations accept one list name. Read-only list views can accept multiple names.
+`list <name> --create` creates a missing list or reuses a unique matching list. Repeating it preserves the list and its reminders; `--json` reports the current incomplete and overdue counts. An ambiguous name fails instead of creating another list.
 List names resolve by exact match, case-insensitive match, then a normalized match that ignores emoji and punctuation.
 If a name is ambiguous, use `--list-id`.
 


### PR DESCRIPTION
`list <name> --create` promises create-if-missing, but repeated calls previously inserted duplicate EventKit calendars and made later mutations by name ambiguous. Resolve the name first, reuse a unique exact/case-insensitive/normalized match, and create only when missing. Ambiguous names still fail without inserting another calendar.

Reused lists retain their reminders and report accurate incomplete/overdue JSON counts through the same counting logic as ordinary list output. The reused-list read targets its exact ID. Regression tests cover name resolution, ambiguity, incomplete/completed reminders, overdue boundaries, empty lists, and isolation between lists with the same title. The commands documentation and Unreleased changelog are updated. Thanks @SebTardif.

Native proof on macOS 26.6.2 with Swift 6.4, running the built Swift CLI against EventKit:

- Current main: two `list <synthetic-name> --create --json` calls returned different IDs; `add --list <synthetic-name>` failed with “matches multiple lists.”
- Patched CLI: repeated creation returned one ID; case-insensitive reuse succeeded.
- After adding four synthetic reminders (three incomplete, one completed; one incomplete overdue), `list <synthetic-name> --create --json` exactly matched ordinary `list --json`: `reminderCount: 3`, `overdueCount: 1`. All four reminders were preserved.
- Every synthetic list and reminder was deleted after proof.

Validation: strict Swift/shell/workflow lint; all 91 Swift tests; isolated RemindCore coverage gate; docs build; credential-free release harness; Codex autoreview of the complete branch through P3, clean.

Exact head: `eb2ea35d1dfe0348a432edfc4d748f34cd244620`. CI: https://github.com/openclaw/remindctl/actions/runs/33984743532.
