### PR TITLE
fix: keep show week half-open like today

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Keep `show week` half-open so a date-only reminder due on the first day of next week is not listed this week. Thanks @SebTardif.
 - Return a calendar-missing error from add, edit, and complete instead of trapping when EventKit leaves a reminder without a calendar after save. Thanks @SebTardif.
 
 ## 0.3.5 - 2026-08-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
-- Keep `show week` half-open so a date-only reminder due on the first day of next week is not listed this week. Thanks @SebTardif.
 - Return a calendar-missing error from add, edit, and complete instead of trapping when EventKit leaves a reminder without a calendar after save. Thanks @SebTardif.
+- Exclude reminders due at the start of next week from `week` and `show week` listings. Thanks @SebTardif.
 
 ## 0.3.5 - 2026-08-30
 

--- a/Sources/RemindCore/ReminderFilter.swift
+++ b/Sources/RemindCore/ReminderFilter.swift
@@ -67,7 +67,7 @@ public enum ReminderFiltering {
       let start = interval?.start ?? startOfToday
       let end = interval?.end ?? now
       return reminders.filter { reminder in
-        let inWeek = reminder.dueDate.map { $0 >= start && $0 <= end } ?? false
+        let inWeek = reminder.dueDate.map { $0 >= start && $0 < end } ?? false
         return !reminder.isCompleted && inWeek
       }
     case .overdue:

--- a/Tests/RemindCoreTests/ReminderFilteringTests.swift
+++ b/Tests/RemindCoreTests/ReminderFilteringTests.swift
@@ -153,4 +153,66 @@ struct ReminderFilteringTests {
     #expect(result.count == 1)
     #expect(result.first?.title == "Completed")
   }
+
+  @Test("Week filter excludes a date-only due on next week's first instant")
+  func weekFilterExcludesNextWeekStart() {
+    var weekCalendar = Calendar(identifier: .gregorian)
+    weekCalendar.timeZone = TimeZone(secondsFromGMT: 0) ?? .current
+    weekCalendar.locale = Locale(identifier: "en_US_POSIX")
+    weekCalendar.firstWeekday = 1
+
+    // Wednesday 2023-11-15 12:00 UTC. Sunday-start week is [2023-11-12, 2023-11-19).
+    let now = Date(timeIntervalSince1970: 1_700_049_600)
+    let interval = weekCalendar.dateInterval(of: .weekOfYear, for: now)
+    #expect(interval != nil)
+    let start = interval?.start ?? now
+    let end = interval?.end ?? now
+
+    let thisWeekStart = ReminderItem(
+      id: "week-start",
+      title: "ThisWeekStart",
+      notes: nil,
+      isCompleted: false,
+      completionDate: nil,
+      priority: .none,
+      dueDate: start,
+      dueDateIsAllDay: true,
+      listID: "a",
+      listName: "Home"
+    )
+    let lastInstantThisWeek = ReminderItem(
+      id: "week-last",
+      title: "LastInstantThisWeek",
+      notes: nil,
+      isCompleted: false,
+      completionDate: nil,
+      priority: .none,
+      dueDate: end.addingTimeInterval(-1),
+      listID: "a",
+      listName: "Home"
+    )
+    let nextWeekStart = ReminderItem(
+      id: "next-week",
+      title: "NextWeekStart",
+      notes: nil,
+      isCompleted: false,
+      completionDate: nil,
+      priority: .none,
+      dueDate: end,
+      dueDateIsAllDay: true,
+      listID: "a",
+      listName: "Home"
+    )
+
+    let result = ReminderFiltering.apply(
+      [thisWeekStart, lastInstantThisWeek, nextWeekStart],
+      filter: .week,
+      now: now,
+      calendar: weekCalendar
+    )
+    let titles = Set(result.map(\.title))
+    #expect(titles.contains("ThisWeekStart"))
+    #expect(titles.contains("LastInstantThisWeek"))
+    #expect(!titles.contains("NextWeekStart"))
+  }
 }

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -19,6 +19,8 @@ remindctl all
 remindctl 2026-01-03
 ```
 
+`week` and `show week` include incomplete reminders due within the current calendar week, including its start but excluding the opening midnight of the next week.
+
 Limit a view to one list:
 
 ```bash


### PR DESCRIPTION
`week` and `show week` included reminders due exactly at the first instant of next week because Foundation's calendar-week interval ends at that instant and the filter used an inclusive upper bound. Use an exclusive end, preserving the inclusive start and incomplete-reminder restriction.

The regression test covers the week start, its final second, and a date-only reminder at next-week midnight. The commands documentation and Unreleased changelog describe the boundary. Thanks @SebTardif.

Native proof on macOS 26.6.2 / Swift 6.4, running the built Swift CLI against EventKit:

- Foundation reported the local week as August 30, 2026 at 00:00 through September 6 at 00:00.
- Created three synthetic reminders: the week start, September 5 at 23:59, and a date-only due on September 6.
- Current main returned all three for both `week --list-id <id> --json` and `show week --list-id <id> --json`.
- This branch returned only the first two for both commands, excluding next-week midnight.
- The synthetic list and all three reminders were deleted after each run.

Validation passed: strict Swift/shell/workflow lint, all 86 Swift tests, 93.6% RemindCore coverage (90% gate), docs build, and Codex autoreview of the complete branch through P3.

Exact head: `284c06c1c4f3bf554510e7c557e7c18d18fb7d09`.
