### PR TITLE
fix(ci): support unreleased notes in the release harness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,9 @@
 
 - Return a calendar-missing error from add, edit, and complete instead of trapping when EventKit leaves a reminder without a calendar after save. Thanks @SebTardif.
 
-## 0.3.5 - 2026-08-30
-
 - Skip fetched reminders with a missing calendar so orphaned rows cannot crash reminder reads. Thanks @SebTardif.
-- Update the docs workflow to Node.js 26 and `actions/setup-node@v7`, and verify the docs build in pull-request CI.
 - Bound `doctor` rich-read sqlite3 probes to 30 seconds so a stuck local database query fails with a timeout instead of hanging the CLI. Thanks @SebTardif.
+- Update the docs workflow to Node.js 26 and `actions/setup-node@v7`, and verify the docs build in pull-request CI.
 
 ## 0.3.4 - 2026-08-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Skip fetched reminders with a missing calendar so orphaned rows cannot crash reminder reads. Thanks @SebTardif.
 - Bound `doctor` rich-read sqlite3 probes to 30 seconds so a stuck local database query fails with a timeout instead of hanging the CLI. Thanks @SebTardif.
 - Update the docs workflow to Node.js 26 and `actions/setup-node@v7`, and verify the docs build in pull-request CI.
+- Keep release-policy tests runnable while release notes are still `Unreleased`, without relaxing the finalized-notes requirement for real releases.
 
 ## 0.3.4 - 2026-08-09
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -36,6 +36,8 @@ On macOS 26.5, `spctl --assess --type execute` rejects known Apple-notarized sta
 
 Local linting requires SwiftLint, ShellCheck, and actionlint.
 
+`make release-harness` uses isolated changelog fixtures and can run while notes are still `Unreleased`. The release preflight and real release downloads continue to require finalized notes for the requested version.
+
 ## Gate 1: protected source and signed tag
 
 After the release commit is on protected `main`, exact-head CI is green, and the tag/public mutation gate is granted:

--- a/scripts/test-release.sh
+++ b/scripts/test-release.sh
@@ -470,6 +470,34 @@ expect_failure "malformed release inventory" env \
 echo "==> downloader rejects malformed and partial inventories atomically"
 mock_api_assets="$work/mock-api-assets"
 mock_release_notes="$work/mock-release-notes.md"
+notes_fixture="$work/notes-fixture"
+mkdir -p "$notes_fixture/scripts"
+cp "$ROOT/scripts/extract-release-notes.sh" "$ROOT/scripts/download-release-assets.sh" \
+  "$ROOT/scripts/release-config.sh" "$notes_fixture/scripts/"
+download_script="$notes_fixture/scripts/download-release-assets.sh"
+printf '# Changelog\n\n## Unreleased\n\n- Pending changes.\n' >"$notes_fixture/CHANGELOG.md"
+expect_failure "unfinalized release notes" \
+  "$notes_fixture/scripts/extract-release-notes.sh" "$MARKETING_VERSION" "$mock_release_notes"
+expect_failure "unfinalized release download" env \
+  GH_BIN="$work/bin/mock-gh" GH_LOG="$work/unfinalized-gh.log" \
+  "$download_script" "$TAG" draft "$work/download-unfinalized"
+[[ ! -e "$work/unfinalized-gh.log" ]] || fail "unfinalized notes contacted GitHub"
+[[ ! -e "$work/download-unfinalized" ]] || fail "unfinalized notes left output behind"
+cat >"$notes_fixture/CHANGELOG.md" <<EOF
+# Changelog
+
+## Unreleased
+
+- Pending changes.
+
+## $MARKETING_VERSION - 2000-01-01
+
+- Synthetic release notes.
+
+## 0.0.0 - 1999-01-01
+
+- Older changes.
+EOF
 mkdir -p "$mock_api_assets"
 printf 'artifact\n' >"$mock_api_assets/$RELEASE_ARTIFACT"
 printf 'checksum\n' >"$mock_api_assets/$RELEASE_CHECKSUMS"
@@ -481,13 +509,15 @@ path, source_commit, tag_object = sys.argv[1:]
 with open(path, "w", encoding="utf-8") as handle:
     json.dump({"sourceCommit": source_commit, "tagObject": tag_object}, handle)
 PY
-"$ROOT/scripts/extract-release-notes.sh" "$MARKETING_VERSION" "$mock_release_notes"
+"$notes_fixture/scripts/extract-release-notes.sh" "$MARKETING_VERSION" "$mock_release_notes"
+printf '\n- Synthetic release notes.\n\n' >"$work/expected-notes.md"
+cmp -s "$mock_release_notes" "$work/expected-notes.md" || fail "release notes included another section"
 env \
   "$draft_token_name=placeholder" GH_BIN="$work/bin/mock-gh" \
   MOCK_TAG="$TAG" MOCK_VERSION="$MARKETING_VERSION" \
   MOCK_RELEASE_BODY_FILE="$mock_release_notes" MOCK_ASSET_DIR="$mock_api_assets" \
   MOCK_SOURCE_COMMIT="$source_commit" MOCK_TAG_OBJECT="$tag_object" \
-  "$ROOT/scripts/download-release-assets.sh" "$TAG" draft "$work/download-valid" >/dev/null
+  "$download_script" "$TAG" draft "$work/download-valid" >/dev/null
 [[ -f "$work/download-valid/source-proof.json" ]] || fail "valid download omitted source proof"
 [[ -d "$work/download-valid/assets" ]] || fail "valid download omitted asset directory"
 metadata_id="$(env \
@@ -502,7 +532,7 @@ for metadata_mode in wrong-title wrong-body wrong-target; do
     MOCK_TAG="$TAG" MOCK_VERSION="$MARKETING_VERSION" \
     MOCK_RELEASE_BODY_FILE="$mock_release_notes" MOCK_ASSET_DIR="$mock_api_assets" \
     MOCK_SOURCE_COMMIT="$source_commit" MOCK_TAG_OBJECT="$tag_object" \
-    "$ROOT/scripts/download-release-assets.sh" "$TAG" draft "$work/download-$metadata_mode"
+    "$download_script" "$TAG" draft "$work/download-$metadata_mode"
   [[ ! -e "$work/download-$metadata_mode" ]] || fail "$metadata_mode left output behind"
 done
 expect_failure "malformed API inventory" env \
@@ -510,35 +540,35 @@ expect_failure "malformed API inventory" env \
   MOCK_TAG="$TAG" MOCK_VERSION="$MARKETING_VERSION" \
   MOCK_RELEASE_BODY_FILE="$mock_release_notes" MOCK_ASSET_DIR="$mock_api_assets" \
   MOCK_SOURCE_COMMIT="$source_commit" MOCK_TAG_OBJECT="$tag_object" \
-  "$ROOT/scripts/download-release-assets.sh" "$TAG" draft "$work/download-malformed"
+  "$download_script" "$TAG" draft "$work/download-malformed"
 [[ ! -e "$work/download-malformed" ]] || fail "malformed download left output behind"
 expect_failure "partial API download" env \
   "$draft_token_name=placeholder" GH_MODE=partial GH_BIN="$work/bin/mock-gh" \
   MOCK_TAG="$TAG" MOCK_VERSION="$MARKETING_VERSION" \
   MOCK_RELEASE_BODY_FILE="$mock_release_notes" MOCK_ASSET_DIR="$mock_api_assets" \
   MOCK_SOURCE_COMMIT="$source_commit" MOCK_TAG_OBJECT="$tag_object" \
-  "$ROOT/scripts/download-release-assets.sh" "$TAG" draft "$work/download-partial"
+  "$download_script" "$TAG" draft "$work/download-partial"
 [[ ! -e "$work/download-partial" ]] || fail "partial download left output behind"
 expect_failure "wrong live default ref" env \
   "$draft_token_name=placeholder" GH_MODE=wrong-default GH_BIN="$work/bin/mock-gh" \
   MOCK_TAG="$TAG" MOCK_VERSION="$MARKETING_VERSION" \
   MOCK_RELEASE_BODY_FILE="$mock_release_notes" MOCK_ASSET_DIR="$mock_api_assets" \
   MOCK_SOURCE_COMMIT="$source_commit" MOCK_TAG_OBJECT="$tag_object" \
-  "$ROOT/scripts/download-release-assets.sh" "$TAG" draft "$work/download-wrong-default"
+  "$download_script" "$TAG" draft "$work/download-wrong-default"
 [[ ! -e "$work/download-wrong-default" ]] || fail "wrong default ref left output behind"
 expect_failure "wrong remote tag object" env \
   "$draft_token_name=placeholder" GH_MODE=wrong-tag GH_BIN="$work/bin/mock-gh" \
   MOCK_TAG="$TAG" MOCK_VERSION="$MARKETING_VERSION" \
   MOCK_RELEASE_BODY_FILE="$mock_release_notes" MOCK_ASSET_DIR="$mock_api_assets" \
   MOCK_SOURCE_COMMIT="$source_commit" MOCK_TAG_OBJECT="$tag_object" \
-  "$ROOT/scripts/download-release-assets.sh" "$TAG" draft "$work/download-wrong-tag"
+  "$download_script" "$TAG" draft "$work/download-wrong-tag"
 [[ ! -e "$work/download-wrong-tag" ]] || fail "wrong tag ref left output behind"
 expect_failure "unverified signed tag" env \
   "$draft_token_name=placeholder" GH_MODE=invalid-signature GH_BIN="$work/bin/mock-gh" \
   MOCK_TAG="$TAG" MOCK_VERSION="$MARKETING_VERSION" \
   MOCK_RELEASE_BODY_FILE="$mock_release_notes" MOCK_ASSET_DIR="$mock_api_assets" \
   MOCK_SOURCE_COMMIT="$source_commit" MOCK_TAG_OBJECT="$tag_object" \
-  "$ROOT/scripts/download-release-assets.sh" "$TAG" draft "$work/download-invalid-signature"
+  "$download_script" "$TAG" draft "$work/download-invalid-signature"
 [[ ! -e "$work/download-invalid-signature" ]] || fail "unverified tag left output behind"
 
 echo "==> published verifier requires both native architecture jobs"


### PR DESCRIPTION
CI's credential-free release harness depended on the real changelog already having a finalized section for the current version. Moving the unpublished 0.3.5 notes back into Unreleased exposed that dependency: the mocked download tests failed before exercising their intended assertions.

Give the harness an isolated changelog fixture containing pending, current-release, and older notes. Copy the unchanged production extractor, downloader, and configuration into that fixture, verify exact section extraction, and prove that unfinalized notes fail before any GitHub call or output. The real release preflight and downloader retain their finalized-notes requirement. The release guide now explains this boundary.

The latest published release and remote tag remain v0.3.4. Consolidate the staged, never-published 0.3.5 notes into Unreleased; preserve all published sections byte-for-byte. PRs #76 and #77 carry their own Unreleased entries. Land all three before finalizing patch 0.3.5.

Validation: ShellCheck, the full credential-free release harness (including the new negative checks), docs build, a direct check that the real 0.3.5 release preflight still rejects unfinalized notes, and Codex autoreview through P3. The unchanged Swift CLI was built and run on macOS 26.6.2: version 0.3.5, full Reminders access. No production release helper or Swift source was changed.

The first CI attempt failed because of the changelog dependency described above. No tag or release was created. Final combined-note dating, protected-main CI, signing, notarization, native architecture verification, clean-VM Gatekeeper/TCC proof, publication, and Homebrew remain release-time gates.
