### PR TITLE
docs: prepare 0.3.6 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+**Highlights:** Clearer alarm guidance and a repaired Homebrew release handoff.
+
+- Clarify in `add`/`edit` help and command docs that `--alarm` schedules a notification without enabling Apple's native Urgent toggle; use Reminders.app to enable Urgent. Thanks @Amitdvl.
+- Unblock Homebrew updates by accepting GitHub's bare release-verifier workflow path while retaining exact branch, source commit, freshness, and native-architecture checks.
+
 ## 0.3.5 - 2026-09-05
 
 **Highlights:** Repeated list creation now preserves existing lists, reminder reads and writes handle missing calendars, and week views respect calendar boundaries.


### PR DESCRIPTION
Collect the complete 0.3.6 Unreleased notes after the v0.3.5 release: clearer notification-alarm guidance (#80) and the repaired Homebrew verifier handoff (#81). Both implementation branches are independent of main and intentionally leave CHANGELOG.md untouched. Land this PR last.

Recommend patch 0.3.6. This PR does not bump version files, create a tag, or publish a release. Commander 0.2.4 and all referenced GitHub Actions release lines are current; pnpm reports no outdated dependencies and its lockfile has no dependency entries.

Validation: changelog-only diff, existing released sections unchanged, P2 autoreview clean. Implementation proof is on #80 and #81; exact-head CI is required on all three PRs and on merged main before release preparation.
